### PR TITLE
Expand testing a bit

### DIFF
--- a/.github/workflows/camsrv-tests.yml
+++ b/.github/workflows/camsrv-tests.yml
@@ -26,6 +26,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install numpy tox
+    - name: Run INDI server in container
+      run: docker run -d --rm -p 7624:7624 mmtobservatory/indilib_server:latest
     - name: Test with tox
       run: |
         tox -e py3${{ matrix.python-ver }}-${{ matrix.tox-env }}

--- a/camsrv/camsrv.py
+++ b/camsrv/camsrv.py
@@ -168,7 +168,6 @@ class CAMsrv(tornado.web.Application):
                     cam.cooling_off()
             self.finish()
 
-
     class DisconnectHandler(tornado.web.RequestHandler):
         """
         Disconnect the camera from the INDI server
@@ -178,7 +177,6 @@ class CAMsrv(tornado.web.Application):
             self.application.camera = None
             log.info("Disconnected camera from INDI server.")
             self.finish()
-
 
     class TemperatureHandler(tornado.web.RequestHandler):
         """

--- a/camsrv/camsrv.py
+++ b/camsrv/camsrv.py
@@ -168,6 +168,18 @@ class CAMsrv(tornado.web.Application):
                     cam.cooling_off()
             self.finish()
 
+
+    class DisconnectHandler(tornado.web.RequestHandler):
+        """
+        Disconnect the camera from the INDI server
+        """
+        def get(self):
+            self.application.camera.quit()
+            self.application.camera = None
+            log.info("Disconnected camera from INDI server.")
+            self.finish()
+
+
     class TemperatureHandler(tornado.web.RequestHandler):
         """
         Set the set-point temperature of the CCD cooler
@@ -336,6 +348,7 @@ class CAMsrv(tornado.web.Application):
         self.handlers = [
             (r"/", self.HomeHandler),
             (r"/expose", self.ExposureHandler),
+            (r"/disconnect", self.DisconnectHandler),
             (r"/latest", self.LatestHandler),
             (r"/cooling", self.CoolingHandler),
             (r"/reset", self.ResetHandler),

--- a/camsrv/tests/test_apps.py
+++ b/camsrv/tests/test_apps.py
@@ -20,6 +20,20 @@ class TestSimSrv(AsyncHTTPTestCase):
         self.assertEqual(response.code, 200)
 
 
+class TestConnected(AsyncHTTPTestCase):
+    def get_app(self):
+        app = CAMsrv(connect=True)
+        return app
+
+    def test_read_then_disconnect(self):
+        response = self.fetch('/status')
+        self.assertEqual(response.code, 200)
+        self.assertIn(b"temperature", response.body)
+
+        response = self.fetch('/disconnect')
+        self.assertEqual(response.code, 200)
+
+
 class TestF9Srv(TestSimSrv):
     def get_app(self):
         app = F9WFSsrv(connect=False)


### PR DESCRIPTION
This PR adds a a callback to fully disconnect the camera from INDI and adds a test with the camera connected to the INDI server. The disconnect callback is then used after testing other server bits so that pytest will exit and return. The testing workflow is modified to run an INDI simulator server via docker that the tests can use.