### PR TITLE
Add docker support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,19 @@
+name: Publish to Docker
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: Publish to Registry
+      uses: docker/build-push-action@v1
+      with:
+        repository: mmtobservatory/camsrv
+        username: ${{ secrets.DOCKER_USER }}
+        password: ${{ secrets.DOCKER_TOKEN }}
+        tags: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:latest
+
+MAINTAINER T. E. Pickering "te.pickering@gmail.com"
+
+COPY . .
+
+RUN pip install -e .[all,test]
+
+WORKDIR /camsrv
+
+ENV WFSROOT /camsrv
+ENV MATCAMROOT /camsrv

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,15 @@
+version: '3.4'
+
+services:
+    f9wfs:
+        build: .
+        volumes:
+            - ${CAMSRV}:/camsrv
+    matcam:
+        build: .
+        volumes:
+            - ${CAMSRV}:/camsrv
+    ratcam:
+        build: .
+        volumes:
+            - ${CAMSRV}:/camsrv

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,15 @@
+version: '3.4'
+
+services:
+    f9wfs:
+        image: mmtobservatory/camsrv:latest
+        volumes:
+            - /home/mmtop/wfsdat:/camsrv
+    matcam:
+        image: mmtobservatory/camsrv:latest
+        volumes:
+            - /mmt/matcam/latest:/camsrv
+    ratcam:
+        image: mmtobservatory/camsrv:latest
+        volumes:
+            - /mmt/matcam/latest:/camsrv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.4'
+
+services:
+    f9wfs:
+        ports:
+            - 8787:8787
+        command: ["f9wfs"]
+    matcam:
+        ports:
+            - 8786:8786
+        command: ["matcam"]
+    ratcam:
+        ports:
+            - 8789:8789
+        command: ["ratcam"]

--- a/docs/matcam/index.rst
+++ b/docs/matcam/index.rst
@@ -12,6 +12,3 @@ Reference/API
 
 .. automodapi:: camsrv.camsrv
     :no-inheritance-diagram:
-
-.. automodapi:: camsrv.matcam
-    :no-inheritance-diagram:


### PR DESCRIPTION
This PR adds configuration to build a docker image, push it to docker hub when master is changed, and use docker-compose to run the set of camera servers via docker.